### PR TITLE
fix: bump dompurify to 3.4.11 (CVE-2026-41238)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
       "esbuild",
       "sharp",
       "core-js"
-    ]
+    ],
+    "overrides": {
+      "dompurify@3.2.7": "^3.4.11"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  dompurify@3.2.7: ^3.4.11
+
 importers:
 
   .:
@@ -2496,8 +2499,8 @@ packages:
     resolution: {integrity: sha512-edTFu0M/7wO1pXY6GDxVNVW086uqwWYIHP98txhcPyV995X21JIH2DtYp33sQJOupYoXKe9RwTw2Ya2vWaquTQ==}
     engines: {node: '>=4'}
 
-  dompurify@3.2.7:
-    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   dts-resolver@2.1.3:
     resolution: {integrity: sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw==}
@@ -6303,7 +6306,7 @@ snapshots:
 
   domain-browser@5.7.0: {}
 
-  dompurify@3.2.7:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -7488,7 +7491,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.2.7
+      dompurify: 3.4.11
       marked: 14.0.0
 
   monaco-types@0.1.2: {}


### PR DESCRIPTION
## Summary

Fixes #10 — bumps the transitive `dompurify` dependency from **3.2.7 → 3.4.11** to remediate **CVE-2026-41238 / GHSA-v9jr-rg53-9pgp** (DOMPurify prototype pollution → XSS bypass via the `CUSTOM_ELEMENT_HANDLING` fallback). Affected range is `3.0.1 – 3.3.3`; fixed in `3.4.0`. Severity **High (CVSS 7.1)**.

## Why an override

`dompurify` is not a direct dependency. It arrives transitively:

```
dompurify@3.2.7
└─ monaco-editor@0.55.1        (peer of @monaco-editor/react)
   └─ @monaco-editor/react@4.7.0
      └─ @react-trace/plugin-preview
```

`monaco-editor` pins `dompurify` to **exactly `3.2.7`**, and the latest published `monaco-editor` (0.55.1) *still* pins 3.2.7 — there is no upstream release that bumps it. The only way to force the patched version is a resolution override, so this adds a scoped `pnpm.overrides` entry:

```jsonc
"overrides": {
  "dompurify@3.2.7": "^3.4.11"
}
```

Scoping to `dompurify@3.2.7` targets only the vulnerable pin without touching any other resolution.

## Verification

- `pnpm why dompurify -r` → **1 version, `dompurify@3.4.11`**
- `pnpm --filter @react-trace/plugin-preview build` → passes
- Lockfile now resolves `monaco-editor@0.55.1 → dompurify: 3.4.11`

## Note for downstream consumers

Because `monaco-editor` is a *peer* dependency of `@monaco-editor/react` and no fixed `monaco-editor` release exists yet, projects installing `@react-trace/plugin-preview` should add the same `overrides` / `resolutions` entry until monaco-editor ships a patched release.
