### PR TITLE
fix(plugin-comments): keep Node-only OpenCode server code out of browser bundles

### DIFF
--- a/.changeset/opencode-client-subpath.md
+++ b/.changeset/opencode-client-subpath.md
@@ -1,0 +1,5 @@
+---
+"@react-trace/plugin-comments": patch
+---
+
+Fix `process is not defined` in browser bundlers (e.g. Vite). The comments plugin imported `@opencode-ai/sdk` from its package root, which re-exports the Node-only `server.js` (`node:child_process`, `process`) and leaked it into the client bundle. It now imports from the browser-safe `@opencode-ai/sdk/client` subpath, and the OpenCode form is loaded via a dynamic `import()` so the SDK lands in its own lazily-fetched chunk.

--- a/packages/plugin-comments/src/CommentsMenu.tsx
+++ b/packages/plugin-comments/src/CommentsMenu.tsx
@@ -10,15 +10,20 @@ import {
   TrashIcon,
   XIcon,
 } from '@react-trace/ui-components'
-import { useEffect, useRef, useState } from 'react'
+import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 
-import { SendToOpencodeForm } from './SendToOpencode'
 import {
   type CommentEntry,
   useCommentEntries,
   useCommentsActions,
 } from './store'
 import { formatCommentNote } from './utils'
+
+// Loaded lazily so `@opencode-ai/sdk` lands in its own chunk and is only
+// fetched when the user actually opens the "Send to OpenCode" form.
+const SendToOpencodeForm = lazy(() =>
+  import('./SendToOpencode').then((m) => ({ default: m.SendToOpencodeForm })),
+)
 
 function CommentRow({
   comment,
@@ -264,15 +269,31 @@ export function CommentsMenu({ onClose }: { onClose(): void }) {
         <>
           <div style={{ borderTop: '1px solid #27272a', margin: '4px 0 0' }} />
           {showSendForm ? (
-            <SendToOpencodeForm
-              root={root}
-              comments={comments}
-              onClearComments={clearAllComments}
-              onDone={() => {
-                setShowSendForm(false)
-                onClose()
-              }}
-            />
+            <Suspense
+              fallback={
+                <div
+                  style={{
+                    padding: '12px',
+                    textAlign: 'center',
+                    fontSize: 12,
+                    color: '#71717a',
+                    fontFamily: 'system-ui, sans-serif',
+                  }}
+                >
+                  Loading…
+                </div>
+              }
+            >
+              <SendToOpencodeForm
+                root={root}
+                comments={comments}
+                onClearComments={clearAllComments}
+                onDone={() => {
+                  setShowSendForm(false)
+                  onClose()
+                }}
+              />
+            </Suspense>
           ) : (
             <div style={{ padding: '4px 6px' }}>
               <DropdownMenu.Item

--- a/packages/plugin-comments/src/SendToOpencode.tsx
+++ b/packages/plugin-comments/src/SendToOpencode.tsx
@@ -1,5 +1,8 @@
-import { createOpencodeClient } from '@opencode-ai/sdk'
-import type { Session } from '@opencode-ai/sdk'
+// Import from the `/client` subpath — the package root re-exports `server.js`,
+// which pulls in Node-only APIs (`node:child_process`, `process`) that break
+// browser bundlers such as Vite. The client entry is browser-safe.
+import { createOpencodeClient } from '@opencode-ai/sdk/client'
+import type { Session } from '@opencode-ai/sdk/client'
 import { useWidgetPortalContainer } from '@react-trace/core'
 import { Button, Select, Textarea } from '@react-trace/ui-components'
 import { useEffect, useRef, useState } from 'react'


### PR DESCRIPTION
Closes #9

## Problem

Importing `@react-trace/kit` (or `@react-trace/plugin-comments` directly) in a browser bundler such as Vite throws **`process is not defined`**.

The dependency chain reported in the issue:

```
@react-trace/kit → @react-trace/plugin-comments → @opencode-ai/sdk → (server code) → process
```

Root cause: `SendToOpencode.tsx` imported from the **package root** `@opencode-ai/sdk`, whose `dist/index.js` does `export * from "./server.js"`. `server.js` statically imports `node:child_process` and reads `process.env` (older SDK versions reached the same code through `cross-spawn` → `which`, which references `process` at module load — matching the stack trace in the issue). Because the plugin only ever needs the **client**, all of that Node-only code was being dragged into the browser bundle.

### Reproduction

Bundling each SDK entry for the browser the way Vite's dep optimizer does:

```
# root entry — FAILS
esbuild --bundle --platform=browser @opencode-ai/sdk/dist/index.js
  ✘ Could not resolve "node:child_process"  (server.js:1)

# client entry — clean
esbuild --bundle --platform=browser @opencode-ai/sdk/dist/client.js
  exit 0
```

## Fix

1. **Import from the browser-safe subpath** `@opencode-ai/sdk/client` (both the `createOpencodeClient` value and the `Session` type). The client entry contains zero Node references, so nothing leaks into the browser bundle. This is the actual fix for `process is not defined`.
2. **Load the form dynamically.** `SendToOpencodeForm` is now `React.lazy(() => import('./SendToOpencode'))`, wrapped in `<Suspense>`. The OpenCode SDK is emitted as its own chunk that is only fetched when the user opens the "Send to OpenCode" form — it's no longer in the main entry chunk at all.

Verified via `tsdown` build: the main `index.js` no longer references `@opencode-ai/sdk`, and a separate `SendToOpencode-*.js` chunk imports `@opencode-ai/sdk/client`. Full workspace `typecheck` (16/16) and `lint` pass. Building the example Vite app succeeds.