### PR TITLE
fix(plugin-preview): explain unavailable folder access (WSL/insecure context)

### DIFF
--- a/.changeset/wsl-folder-access-feedback.md
+++ b/.changeset/wsl-folder-access-feedback.md
@@ -1,0 +1,5 @@
+---
+"@react-trace/plugin-preview": patch
+---
+
+Explain when folder access is unavailable instead of silently failing. The File System Access API (`showDirectoryPicker`) only exists in a secure context and in Chromium-based browsers, but the folder picker prompt always showed a "Grant access" button that quietly did nothing when the API was missing. It now detects the reason and shows guidance — WSL users reaching the dev server via the VM's IP (an insecure context) are told to use `http://localhost` instead, and non-Chromium browsers are told to switch. Addresses #8.

--- a/packages/plugin-preview/src/FolderAccessPrompt.tsx
+++ b/packages/plugin-preview/src/FolderAccessPrompt.tsx
@@ -1,6 +1,8 @@
 import { IS_MAC } from '@react-trace/core'
 import { Button, FolderIcon, Kbd, KbdGroup } from '@react-trace/ui-components'
 
+import { getFileSystemSupport } from './fs'
+
 export function FolderAccessPrompt({
   root,
   onGrant,
@@ -10,6 +12,15 @@ export function FolderAccessPrompt({
   onGrant(): void
   onCancel(): void
 }) {
+  const support = getFileSystemSupport()
+
+  // When the File System Access API isn't available, "Grant access" would
+  // silently do nothing (the native folder picker never opens). Explain why
+  // and how to fix it instead — this is what WSL users hit (issue #8).
+  if (!support.supported) {
+    return <UnsupportedPrompt reason={support.reason} onCancel={onCancel} />
+  }
+
   return (
     <div
       style={{
@@ -75,6 +86,67 @@ export function FolderAccessPrompt({
           Grant access
         </Button>
       </div>
+    </div>
+  )
+}
+
+function UnsupportedPrompt({
+  reason,
+  onCancel,
+}: {
+  reason: 'insecure-context' | 'unsupported-browser'
+  onCancel(): void
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 12,
+        padding: '20px 16px',
+        height: '100%',
+        boxSizing: 'border-box',
+        textAlign: 'center',
+        fontFamily: 'system-ui, sans-serif',
+      }}
+    >
+      <span style={{ color: '#52525b' }}>
+        <FolderIcon />
+      </span>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <span style={{ fontSize: 13, fontWeight: 600, color: '#fafafa' }}>
+          Folder access unavailable
+        </span>
+        <span style={{ fontSize: 12, color: '#71717a', lineHeight: 1.5 }}>
+          {reason === 'insecure-context' ? (
+            <span style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              <span>
+                Source preview needs a secure context. Open the app from{' '}
+                <span
+                  style={{
+                    fontFamily: 'ui-monospace, monospace',
+                    color: '#3b82f6',
+                  }}
+                >
+                  http://localhost
+                </span>{' '}
+                (or HTTPS) rather than an IP address.
+              </span>
+              <span>
+                In WSL, reach the dev server via localhost instead of the VM's
+                IP.
+              </span>
+            </span>
+          ) : (
+            "Your browser doesn't support the File System Access API. Use a Chromium-based browser such as Chrome or Edge."
+          )}
+        </span>
+      </div>
+      <Button variant="secondary" onClick={onCancel}>
+        Close
+      </Button>
     </div>
   )
 }

--- a/packages/plugin-preview/src/fs.ts
+++ b/packages/plugin-preview/src/fs.ts
@@ -31,6 +31,34 @@ export interface FileSystemService {
   write(relativePath: string, content: string): Promise<void>
 }
 
+/**
+ * Why the File System Access API can't be used, when it can't:
+ * - `insecure-context`: `showDirectoryPicker` is only exposed in secure
+ *   contexts (localhost or HTTPS). This is the common WSL case, where the dev
+ *   server is reached via the VM's IP address (e.g. http://172.x.x.x:3000)
+ *   rather than http://localhost — see issue #8.
+ * - `unsupported-browser`: a non-Chromium browser (Firefox, Safari) that
+ *   doesn't implement the File System Access API at all.
+ */
+export type FileSystemSupport =
+  | { supported: true }
+  | { supported: false; reason: 'insecure-context' | 'unsupported-browser' }
+
+export function getFileSystemSupport(): FileSystemSupport {
+  if (typeof window === 'undefined')
+    return { supported: false, reason: 'unsupported-browser' }
+  // Read before the `in` check below: lib.dom types `showDirectoryPicker` as
+  // always-present, so that narrowing collapses `window` to `never` and any
+  // later `window.*` access stops type-checking.
+  const secureContext = window.isSecureContext
+  if ('showDirectoryPicker' in window) return { supported: true }
+  // The API is missing. In an insecure context it's stripped from `window`
+  // even on Chromium, so treat that as the more actionable reason.
+  if (!secureContext)
+    return { supported: false, reason: 'insecure-context' }
+  return { supported: false, reason: 'unsupported-browser' }
+}
+
 const IDB_NAME = 'react-trace'
 const IDB_STORE = 'handles'
 const IDB_KEY = 'root-directory'
@@ -103,7 +131,7 @@ class FileSystemServiceImpl implements FileSystemService {
   private _listeners = new Set<() => void>()
 
   get isSupported(): boolean {
-    return typeof window !== 'undefined' && 'showDirectoryPicker' in window
+    return getFileSystemSupport().supported
   }
 
   get hasAccess(): boolean {


### PR DESCRIPTION
Refs #8

## Problem

In WSL, the "Grant access" folder prompt appears but clicking it does nothing — the native folder picker never opens, so users "don't see the folder selection section."

Root cause: the preview plugin relies on the **File System Access API** (`window.showDirectoryPicker`), which is only exposed:
- in a **secure context** (localhost or HTTPS), and
- in **Chromium-based** browsers (not Firefox/Safari).

WSL2 users very commonly reach their dev server through the VM's IP address (e.g. `http://172.20.x.x:3000`), which is **not** a secure context, so `showDirectoryPicker` is absent. But `fs.ts` silently returned `false` from `requestAccess()`/`tryRestore()` and the prompt always rendered a "Grant access" button — clicking it just no-opped with zero feedback.

## Fix

This can't be fully reproduced without a Windows/WSL machine, so rather than guess at a platform-specific workaround, this makes the failure **legible**:

- `getFileSystemSupport()` in `fs.ts` now reports *why* the API is unavailable: `insecure-context` vs `unsupported-browser` (reading `window.isSecureContext`).
- `FolderAccessPrompt` renders actionable guidance when unsupported instead of a dead "Grant access" button:
  - **insecure context** (the WSL-via-IP case) → "Open the app from `http://localhost` (or HTTPS) rather than an IP address. In WSL, reach the dev server via localhost instead of the VM's IP."
  - **non-Chromium browser** → "Use a Chromium-based browser such as Chrome or Edge."

The existing `isSupported` getter now delegates to the same helper, so there's a single source of truth.

## Verification

Detection logic exercised against all four environments:

| Environment | Result |
|---|---|
| Chromium on localhost (secure + API) | `{ supported: true }` |
| Chrome via WSL IP (insecure, no API) | `insecure-context` |
| Firefox on localhost (secure, no API) | `unsupported-browser` |
| SSR (no `window`) | `unsupported-browser` |

Full workspace `typecheck` (16/16) and `lint` pass.

## Note

This is a UX/diagnostics improvement — it tells WSL users how to get folder access working (use `localhost`), which for most setups is the actual fix. If it turns out you'd rather *hide* the folder toolbar button entirely when unsupported (instead of showing it and explaining on click), that's a small follow-up — I kept the button visible since the reporter expected to see it.