### PR TITLE
docs(plugin-preview): document dompurify override for consumers

### DIFF
--- a/packages/plugin-preview/README.md
+++ b/packages/plugin-preview/README.md
@@ -12,6 +12,46 @@ pnpm add --dev @react-trace/core @react-trace/ui-components @react-trace/plugin-
 
 If you are already using `@react-trace/kit`, this plugin is included there by default.
 
+## Security note: `dompurify`
+
+This plugin renders source through Monaco (`@monaco-editor/react` → `monaco-editor`). `monaco-editor` pins `dompurify` to an exact version that currently sits inside the affected range of [CVE-2026-41238 / GHSA-v9jr-rg53-9pgp](https://github.com/advisories/GHSA-v9jr-rg53-9pgp) (prototype pollution → XSS bypass, fixed in `dompurify` `3.4.0`).
+
+`monaco-editor` has not yet released a version that bumps `dompurify`, so a security scanner will flag the transitive `dompurify` in your install. Until an upstream fix ships, force a patched version in **your own app** with a package-manager override, then reinstall:
+
+**pnpm** — in `package.json`:
+
+```json
+{
+  "pnpm": {
+    "overrides": {
+      "dompurify": "^3.4.11"
+    }
+  }
+}
+```
+
+**npm** — in `package.json`:
+
+```json
+{
+  "overrides": {
+    "dompurify": "^3.4.11"
+  }
+}
+```
+
+**Yarn** — in `package.json`:
+
+```json
+{
+  "resolutions": {
+    "dompurify": "^3.4.11"
+  }
+}
+```
+
+An override has to live in the consuming application's `package.json` — it cannot be shipped from within this package — which is why the fix is documented here rather than resolved by a dependency bump.
+
 ## Usage
 
 ```tsx


### PR DESCRIPTION
## Summary

Follow-up to #11. Documents a copy-paste `dompurify` override in the `@react-trace/plugin-preview` README so downstream consumers whose security scanners flag **CVE-2026-41238 / GHSA-v9jr-rg53-9pgp** have a self-serve fix.

## Why docs and not a dependency bump

`@react-trace/plugin-preview` **externalizes** `@monaco-editor/react` — the built dist (~20KB) contains no monaco/dompurify code, just an external `import`. So `monaco-editor` → `dompurify` is resolved and bundled in the **consumer's** install, not shipped inlined by us. Combined with:

- `monaco-editor` pinning `dompurify` to an affected version, and
- no fixed `monaco-editor` release existing yet (0.55.1, the latest, still pins 3.2.7),

…a library-side change can't force the patched version into a consumer's tree. An override has to live in the consuming app's `package.json`. This PR documents exactly that, with `pnpm` / `npm` / `yarn` variants.

The repo's own dependency tree (and our bundled `apps/website` + `apps/example`) is already fixed by the override in #11.

## Change

- Adds a **"Security note: `dompurify`"** section to `packages/plugin-preview/README.md`.

Docs-only; no code or dependency changes.

Refs #10, #11
