### PR TITLE
fix(core): keep ActionPanel submenu open when hovering into it

### DIFF
--- a/packages/core/src/components/ActionPanel.tsx
+++ b/packages/core/src/components/ActionPanel.tsx
@@ -7,7 +7,7 @@ import {
 } from '@react-trace/ui-components'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import type { ReactNode } from 'react'
-import { useCallback } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import {
   portalContainerAtom,
@@ -257,6 +257,8 @@ export function ActionPanel({ plugins }: ActionPanelProps) {
   )
 }
 
+const SUBMENU_CLOSE_DELAY_MS = 150
+
 function Submenu({
   entryContent,
   plugins,
@@ -268,15 +270,40 @@ function Submenu({
 }) {
   const portalContainer = useAtomValue(portalContainerAtom)
   const setSelectedSource = useSetAtom(selectedSourceAtom)
+  const [open, setOpen] = useState(false)
+  const closeTimerRef = useRef<number | undefined>(undefined)
+
+  useEffect(() => {
+    return () => window.clearTimeout(closeTimerRef.current)
+  }, [])
+
+  const keepOpen = useCallback(() => {
+    window.clearTimeout(closeTimerRef.current)
+    setOpen(true)
+    setSelectedSource(source)
+  }, [source, setSelectedSource])
+
+  const scheduleClose = useCallback(() => {
+    window.clearTimeout(closeTimerRef.current)
+    closeTimerRef.current = window.setTimeout(() => setOpen(false), SUBMENU_CLOSE_DELAY_MS)
+  }, [])
 
   return (
     <DropdownMenu.Root
-      onOpenChange={(open) => open && setSelectedSource(source)}
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next)
+        if (next) {
+          window.clearTimeout(closeTimerRef.current)
+          setSelectedSource(source)
+        }
+      }}
     >
       <DropdownMenu.Trigger
-        openOnHover
-        delay={0}
-        closeDelay={0}
+        onMouseEnter={keepOpen}
+        onMouseLeave={scheduleClose}
+        onFocus={keepOpen}
+        onBlur={scheduleClose}
         style={(state) => entryStyle(state.open)}
       >
         {entryContent}
@@ -301,6 +328,8 @@ function Submenu({
           style={{ zIndex: 999999, pointerEvents: 'auto' }}
         >
           <DropdownMenu.Popup
+            onMouseEnter={keepOpen}
+            onMouseLeave={scheduleClose}
             style={{
               minWidth: 200,
               paddingBlock: plugins.length > 0 ? 4 : 0,


### PR DESCRIPTION
## Fix: ActionPanel source submenu closes when moving the mouse into it

Fixes #16

### Problem

In the element inspector's action panel, hovering a source entry opens the plugin submenu (code preview + "Add comment" / "Copy path" actions), but the submenu disappears as soon as the mouse moves into it — even while the pointer is still inside the popup. Clicking entries is also flaky ("buttons sometimes unclickable") because the menu can close before the click lands.

### Root cause

The `Submenu` used `DropdownMenu.Trigger` with `openOnHover`, `delay={0}`, `closeDelay={0}`. Base UI's hover-close path is governed by floating-ui's `safePolygon`, which only keeps the popup open if the pointer travels through a narrow safe zone between the trigger and the popup:

- The popup (up to ~480px wide, e.g. the folder-access prompt) is much taller and wider than the ~315px trigger entry, and when the viewport lacks room it flips to the opposite side (`side="right"` with `collisionPadding`).
- The safe-polygon geometry is anchored once at the pointer-leave position and can be near-degenerate (the cursor point is offset by only `POLYGON_BUFFER / 2` = 0.25px from the cursor), so any diagonal traversal or small vertical deviation while crossing the 4px gap exits the polygon and closes the menu — even though the pointer is about to enter (or is already inside) the popup's bounding box.
- `closeDelay={0}` means any missed "landing" closes the menu immediately.

### Fix

Replace the `openOnHover`/safePolygon close behavior with a standard hover-intent pattern that react-trace fully controls:

- Controlled `open` state on the `DropdownMenu.Root`.
- Open on hover/focus of the trigger; close with a **150ms grace period** (`SUBMENU_CLOSE_DELAY_MS`) that is cancelled whenever the pointer is over the trigger **or** the popup.
- Set the selected source (`setSelectedSource`) when opening via hover too — previously the hover-open path (which goes through the controlled `open` prop) never ran `setSelectedSource`, so the plugin action panels rendered an empty popup on the first hover until a click opened the menu through `onOpenChange`.

### Verification

Reproduced the original bug headlessly against a dev server (popup closed 3px inside its edge while moving the mouse in), then verified the fix:

- 25-step approach into the popup: stays open through every step (was closing at step ~24).
- Fast single-jump move into the popup: stays open (was closing on the first move).
- Fresh page load, first hover: popup opens at full size with content, stays open when moving in.
